### PR TITLE
Fix linux .sh for Tools-Suite

### DIFF
--- a/index.html
+++ b/index.html
@@ -201,7 +201,8 @@
                     }
                     let shTest = isExt(element.name, '.sh');
                     if (shTest) {
-                        addSuiteListItem(element, 'AMO Suite Mac (.sh)');
+                        const s = (macTest) ? 'Mac (.sh)' : 'Linux (.sh)';
+                        addSuiteListItem(element, 'AMO Suite ' + s);
                     }
                     let exeTest = isExt(element.name, '.exe');
                     if (exeTest) {


### PR DESCRIPTION
changes code the allow for mac `.sh` as well as linux `.sh` installers for the tools-suite